### PR TITLE
Allow functions to push multiple replies into the read buffer

### DIFF
--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -103,7 +103,7 @@ class BaseMocker(metaclass=MockerMetaClass):
             raise ValueError(f"Unknown SCPI command {scpi_string}")
 
         new_function = function
-        return str(new_function(self, *args))
+        return new_function(self, *args)
 
 
 scpi = BaseMocker.scpi


### PR DESCRIPTION
This is needed for instruments with multipart replies to read messages. 

Please let me know if this will be acceptable then I will add test and docs as needed

The explicit cast to string needs to go to allow lists and tuples to pass through but we could still cast ints and floats to str if needed