### PR TITLE
add call_delay to BaseMocker and SCPIHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ class MockerChannel(BaseMocker):
     """
     
     def __init__(self): 
+        super().__init__()
         self._voltage = 0
     
     # Lets define handler functions. Notice how we can be 
@@ -39,6 +40,7 @@ class Mocker(BaseMocker):
     """
 
     def __init__(self):
+        super().__init__()
         self._channels = defaultdict(MockerChannel)
 
     @scpi("\*IDN\?")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(requirements_fname) as fp:
 
 setup(
     name="pyvisa-mock",
-    version="0.3",
+    version="0.4",
     packages=find_packages(),
     python_requires='>=3.6.*',
     install_requires=install_requires,

--- a/visa_mock/base/base_mocker.py
+++ b/visa_mock/base/base_mocker.py
@@ -148,7 +148,20 @@ class BaseMocker(metaclass=MockerMetaClass):
     def __init__(self, call_delay: float = 0.0):
         self._call_delay = call_delay
 
-    def set_call_delay(self, call_delay: float, scpi_string: Optional[str] = None):
+    def set_call_delay(
+            self,
+            call_delay: float,
+            scpi_string: Optional[str] = None
+    ) -> None:
+        """
+        This method set the call delay to either the whole instrument, or the
+        scpi command specified.
+
+        Args:
+            call_delay: the intended delay value in second.
+            scpi_string: when provided, this method will apply the call_delay
+                to this scpi command only.
+        """
         if scpi_string is None:
             self._call_delay = call_delay
         else:

--- a/visa_mock/test/base/test_delays.py
+++ b/visa_mock/test/base/test_delays.py
@@ -1,49 +1,35 @@
-from visa_mock.test.mock_instruments.instruments import Mocker1
+import pytest
 import time
+from visa_mock.base.base_mocker import BaseMocker
+from visa_mock.test.mock_instruments.instruments import Mocker1
+
+
+def time_command(mocker: BaseMocker, command: str) -> float:
+    start = time.time()
+    mocker.send(command)
+    return time.time() - start
 
 
 def test_delay_on_instrument():
-    call_delay = 1
+    call_delay = 1.0        # unit: [sec]
     mocker = Mocker1()
 
-    # At first, there is no delay:
-    t0 = time.time()
-    mocker.send(":INSTR:CHANNEL1:VOLT?")
-    call_time0 = time.time() - t0
-    assert 0 <= call_time0 < 0.1
-
-    # Now, to introduce the delay to the whole instrument
+    # By default, there is no delay:
+    time_w_no_delay = time_command(mocker, ":INSTR:CHANNEL1:VOLT?")
+    # To introduce the delay to the whole instrument:
     mocker.set_call_delay(call_delay)
-
-    # all the commands will have the same delay:
-    t1 = time.time()
-    mocker.send(":INSTR:CHANNEL1:VOLT 12")
-    call_time1 = time.time() - t1
-    assert 0 <= (call_time1 - call_time0 - call_delay) < 0.1
-
-    t2 = time.time()
-    voltage = mocker.send(":INSTR:CHANNEL1:VOLT?")
-    call_time2 = time.time() - t2
-    assert 0 <= (call_time2 - call_time0 - call_delay) < 0.1
-    assert voltage == "12.0"
+    time_w_delay = time_command(mocker, ":INSTR:CHANNEL1:VOLT?")
+    assert time_w_delay - time_w_no_delay == pytest.approx(call_delay, 0.1)
 
 
 def test_delay_on_command():
-    call_delay = 2
+    call_delay = 2.0        # unit: [sec]
     mocker = Mocker1()
-
-    cmd = ":INSTR:CHANNEL(.*):VOLT (.*)"
+    cmd_w_delay = ":INSTR:CHANNEL(.*):VOLT (.*)"
 
     # To introduce delay to one cmd only:
-    mocker.set_call_delay(call_delay, cmd)
-    assert mocker.__scpi_dict__[cmd].call_delay == call_delay
-    t0 = time.time()
-    mocker.send(":INSTR:CHANNEL1:VOLT 12")
-    t1 = time.time()
-    assert call_delay <= (t1 - t0) < call_delay + 0.1
-
-    # Other commands should not have any delay:
-    voltage = mocker.send(":INSTR:CHANNEL1:VOLT?")
-    t0 = time.time()
-    assert 0 <= (time.time() - t0) < 0.1
-    assert voltage == "12.0"
+    mocker.set_call_delay(call_delay, cmd_w_delay)
+    time_w_delay = time_command(mocker, ":INSTR:CHANNEL1:VOLT 12")
+    # Other comands should have no delay:
+    time_w_no_delay = time_command(mocker, ":INSTR:CHANNEL1:VOLT?")
+    assert time_w_delay - time_w_no_delay == pytest.approx(call_delay, 0.1)

--- a/visa_mock/test/base/test_delays.py
+++ b/visa_mock/test/base/test_delays.py
@@ -1,0 +1,46 @@
+from visa_mock.test.mock_instruments.instruments import Mocker1
+import time
+
+
+def test_delay_on_instrument():
+    call_delay = 1
+    mocker = Mocker1()
+
+    # At first, there is no delay:
+    t0 = time.time()
+    mocker.send(":INSTR:CHANNEL1:VOLT?")
+    assert 0 <= (time.time() - t0) < 1
+
+    # Now, to introduce the delay to the whole instrument
+    mocker.set_call_delay(call_delay)
+
+    # all the commands will have the same delay:
+    t0 = time.time()
+    mocker.send(":INSTR:CHANNEL1:VOLT 12")
+    assert call_delay <= (time.time() - t0) < call_delay + 1
+
+    t0 = time.time()
+    voltage = mocker.send(":INSTR:CHANNEL1:VOLT?")
+    assert call_delay <= (time.time() - t0) < call_delay + 1
+    assert voltage == "12.0"
+
+
+def test_delay_on_command():
+    call_delay = 2
+    mocker = Mocker1()
+
+    cmd = ":INSTR:CHANNEL(.*):VOLT (.*)"
+
+    # To introduce delay to one cmd only:
+    mocker.set_call_delay(call_delay, cmd)
+    assert mocker.__scpi_dict__[cmd].call_delay == call_delay
+    t0 = time.time()
+    mocker.send(":INSTR:CHANNEL1:VOLT 12")
+    t1 = time.time()
+    assert call_delay <= (t1 - t0) < call_delay + 1
+
+    # Other commands should not have any delay:
+    voltage = mocker.send(":INSTR:CHANNEL1:VOLT?")
+    t0 = time.time()
+    assert 0 <= (time.time() - t0) < 1
+    assert voltage == "12.0"

--- a/visa_mock/test/base/test_delays.py
+++ b/visa_mock/test/base/test_delays.py
@@ -9,19 +9,22 @@ def test_delay_on_instrument():
     # At first, there is no delay:
     t0 = time.time()
     mocker.send(":INSTR:CHANNEL1:VOLT?")
-    assert 0 <= (time.time() - t0) < 1
+    call_time0 = time.time() - t0
+    assert 0 <= call_time0 < 0.1
 
     # Now, to introduce the delay to the whole instrument
     mocker.set_call_delay(call_delay)
 
     # all the commands will have the same delay:
-    t0 = time.time()
+    t1 = time.time()
     mocker.send(":INSTR:CHANNEL1:VOLT 12")
-    assert call_delay <= (time.time() - t0) < call_delay + 1
+    call_time1 = time.time() - t1
+    assert 0 <= (call_time1 - call_time0 - call_delay) < 0.1
 
-    t0 = time.time()
+    t2 = time.time()
     voltage = mocker.send(":INSTR:CHANNEL1:VOLT?")
-    assert call_delay <= (time.time() - t0) < call_delay + 1
+    call_time2 = time.time() - t2
+    assert 0 <= (call_time2 - call_time0 - call_delay) < 0.1
     assert voltage == "12.0"
 
 
@@ -37,10 +40,10 @@ def test_delay_on_command():
     t0 = time.time()
     mocker.send(":INSTR:CHANNEL1:VOLT 12")
     t1 = time.time()
-    assert call_delay <= (t1 - t0) < call_delay + 1
+    assert call_delay <= (t1 - t0) < call_delay + 0.1
 
     # Other commands should not have any delay:
     voltage = mocker.send(":INSTR:CHANNEL1:VOLT?")
     t0 = time.time()
-    assert 0 <= (time.time() - t0) < 1
+    assert 0 <= (time.time() - t0) < 0.1
     assert voltage == "12.0"

--- a/visa_mock/test/mock_instruments/instruments.py
+++ b/visa_mock/test/mock_instruments/instruments.py
@@ -9,6 +9,7 @@ class Mocker1(BaseMocker):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self._voltage = defaultdict(lambda: 0.0)
 
     @scpi(r":INSTR:CHANNEL(.*):VOLT (.*)")
@@ -27,6 +28,7 @@ class Mocker2(BaseMocker):
     """
 
     def __init__(self):
+        super().__init__()
         self._voltage = defaultdict(lambda: 0.0)
 
     @scpi(r":INSTR:CHANNEL(.*):VOLT (.*)")
@@ -41,6 +43,7 @@ class Mocker2(BaseMocker):
 class MockerChannel(BaseMocker):
 
     def __init__(self):
+        super().__init__()
         self._voltage = 0
 
     @scpi(r":VOLT (.*)")
@@ -55,7 +58,7 @@ class MockerChannel(BaseMocker):
 class Mocker3(BaseMocker):
 
     def __init__(self):
-
+        super().__init__()
         self._channels = {
             1: MockerChannel(),
             2: MockerChannel()
@@ -69,6 +72,7 @@ class Mocker3(BaseMocker):
 class Mocker4(BaseMocker):
 
     def __init__(self):
+        super().__init__()
         self._instruments = {
             1: Mocker3(),
             2: Mocker3()


### PR DESCRIPTION
A new parameter "call_delay" is added to both BaseMocker and SCPIHandler calss, and a new method "set_call_delay". With these changes, we can not only add a delay on the instrument as a whole but also in on only some scpi commands. A test file "test_delay.py" has also been added.

The version is updated to 0.4.